### PR TITLE
Change shortcuts to avoid conflict

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,3 @@
 [
-  { "keys": ["ctrl+g", "ctrl+r"], "command": "golden_ratio"}
+  { "keys": ["ctrl+k", "ctrl+r"], "command": "golden_ratio"}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,3 +1,3 @@
 [
-  { "keys": ["super+g", "super+r"], "command": "golden_ratio"}
+  { "keys": ["super+k", "super+r"], "command": "golden_ratio"}
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,3 @@
 [
-  { "keys": ["ctrl+g", "ctrl+r"], "command": "golden_ratio"}
+  { "keys": ["ctrl+k", "ctrl+r"], "command": "golden_ratio"}
 ]

--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Use `Preferences -> Package Settings -> GoldenRatio`
 Keymaps
 -------
 
-* Windows and Linux `ctrl+g ctrl+r` 
-* Mac OS `super+g super+r`
+* Windows and Linux `ctrl+k ctrl+r
+* Mac OS `super+k super+r`
 
 Credits
 -------


### PR DESCRIPTION
The `Command + G` shortcut conflicts with the "Find next" shortcut on Sublime 3.

This PR changes the shortcuts to `Command + K, Command + R` to avoid the conflict and follow Sublime's existing multi-step shortcuts.
